### PR TITLE
[Serializer] Use Instantiated Class Name During Denormalization

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -247,7 +247,8 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
         $reflectionClass = new \ReflectionClass($class);
         $object = $this->instantiateObject($normalizedData, $class, $context, $reflectionClass, $allowedAttributes, $format);
-
+        $class = get_class($object);
+        
         foreach ($normalizedData as $attribute => $value) {
             if ($this->nameConverter) {
                 $attribute = $this->nameConverter->denormalize($attribute);


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 4.0 
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no   
| Deprecations? | no 
| Tests pass?   | yes    
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

When using a class discriminator for an abstract class, the subclass may contain additional properties. These properties were not being denormalized correctly because the abstract class was being passed to the denormalizer instead of the subclass.

```
/**
 * @DiscriminatorMap(typeProperty="type", mapping={
 *    "class1"="SubClass"
 * })
 */
abstract class BaseClass
{
    public $type;
}

class SubClass extends BaseClass {

  public $date;
  
  public function setDate(\DateTime $date) {
    $this->date = $date;
  }
}
```


Sample JSON:
```
  {
    "type": "class1",
    "date": "2016-11-13T05:00:00-05:00",
  }
  ```

When the json is deserialized, the denormalizer only uses reflection to examine the BaseClass for proper field mappings. So the "date" field on the SubClass is not being properly mapped as a DateTime object. I propose that after the object is instantiated, we reset the class name that is being denormalized to be the class of the object. This will ensure that the child class will be used during the reflection checks.
